### PR TITLE
Fix deploy to OpenShift script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "ci": "npm run lint && npm run coveralls",
     "release": "standard-version -a",
-    "openshift": "nodeshift --dockerImage=registry.access.redhat.com/ubi8/nodejs-14:latest",
+    "openshift": "nodeshift --dockerImage=registry.access.redhat.com/ubi8/nodejs-14",
     "postinstall": "license-reporter report -s && license-reporter save -s --xml licenses.xml",
     "start": "node ."
   },


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

Hello! I think the image form openshift script should be without tag to avoid an error like:
```
ERROR BuildConfig.build.openshift.io "nodejs-configmap-s2i" is invalid: spec.strategy.sourceStrategy.from.name: Invalid value: "registry.access.redhat.com/ubi8/nodejs-14:latest:latest": not a valid Docker pull specification: invalid reference format
``` 