### PR TITLE
chore: change default dockerImage to ubi8/nodejs-16

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pretest": "eslint --ignore-path .gitignore .",
     "test": "nyc --reporter=lcov mocha",
     "release": "standard-version -a",
-    "openshift": "nodeshift --dockerImage=registry.access.redhat.com/ubi8/nodejs-14",
+    "openshift": "nodeshift --dockerImage=registry.access.redhat.com/ubi8/nodejs-16",
     "start": "node ."
   },
   "main": "./bin/www",


### PR DESCRIPTION
The application runs with Node.js 16, but there appears to be a general issue with loading the config which is independent from the Node.js version.